### PR TITLE
django 3.0 fix (staticfiles)

### DIFF
--- a/templates/base_2.html
+++ b/templates/base_2.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="ru">
 <head>


### PR DESCRIPTION
staticfiles tag removed from django 3. 0 and replaced with static